### PR TITLE
fix: export types + set headers onRequest instead of onSend to allow …

### DIFF
--- a/framework/local/index.ts
+++ b/framework/local/index.ts
@@ -41,7 +41,7 @@ export function serveHandler(handler: Handler, port = 8080) {
     done();
   });
 
-  server.addHook("onSend", function (request, reply, payload, done) {
+  server.addHook("onRequest", function (request, reply, done) {
     // Those headers are added for convenience, but will be overwritten if set in the handler
     reply.header("Access-Control-Allow-Origin", "*");
     reply.header("Access-Control-Allow-Headers", "Content-Type");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scaleway/serverless-functions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@scaleway/serverless-functions",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/url-data": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "",
   "main": "framework/dist/local/index.js",
-  "types": "dist/local/index.d.ts",
+  "types": "framework/dist/local/index.d.ts",
   "scripts": {
     "build": "node_modules/.bin/tsc -p tsconfig.json",
     "format": "prettier --write ."


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Export types correctly (wrong path before)
- Set headers onRequest instead of onSend to allow users to overwrite them

**_Why do we need this?_**

**_How have you tested it?_**

## Checklist

- [X] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
