### PR TITLE
chore(tidy): clean up README and badges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 ---
+name: "build"
+
 on:
   push:
     branches: ["main"]
@@ -9,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  build:
     strategy:
       matrix:
         node-version: ["16.x", "18.x"]

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,66 @@
+---
+name: "examples"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  examples:
+    strategy:
+      matrix:
+        node-version: ["16.x", "18.x"]
+        example:
+          [
+            "not_stringified_body",
+            "print_event_context",
+            "stringified_body",
+            "upload_file_multipart",
+            "with_callback",
+            "with_event_components",
+            "with_http_get",
+            "with_http_post",
+            "with_object",
+            "with_promise",
+          ]
+
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Set up node ${{ matrix.node-version }}"
+        id: setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ matrix.node-version }}"
+          cache: "npm"
+
+      - name: "Install framework dependencies"
+        run: npm ci
+
+      - name: "Build framework"
+        run: npm run build
+
+      - name: "Install examples dependencies"
+        run: npm ci
+        working-directory: examples
+
+      - name: "Link framework"
+        run: npm link
+
+      - name: "Link framework in examples"
+        run: npm link @scaleway/serverless-functions
+        working-directory: examples
+
+      - name: "Run example"
+        run: node ${{ matrix.example }}/handler.js &
+        working-directory: examples
+
+      - name: "Wait for it to start"
+        run: sleep 1
+
+      - name: "Launch a request"
+        run: curl http://localhost:8080
+        working-directory: examples

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -61,6 +61,13 @@ jobs:
       - name: "Wait for it to start"
         run: sleep 1
 
-      - name: "Launch a request"
+      - name: "Send a GET request"
         run: curl http://localhost:8080
+        working-directory: examples
+
+      - name: "Send a POST request"
+        run: >
+          curl -X POST
+          -d '{"foo": "bar"}'
+          http://localhost:8080
         working-directory: examples

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 ---
+name: "publish"
+
 on:
   release:
     types: [published]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 ---
+name: "tests"
+
 on:
   push:
     branches: ["main"]
@@ -26,58 +28,3 @@ jobs:
 
       - name: "Run tests"
         run: npm test
-
-  examples:
-    defaults:
-      run:
-        working-directory: ./examples
-
-    strategy:
-      matrix:
-        node-version: ["16.x", "18.x"]
-        example:
-          [
-            "not_stringified_body",
-            "print_event_context",
-            "stringified_body",
-            "upload_file_multipart",
-            "with_callback",
-            "with_event_components",
-            "with_http_get",
-            "with_http_post",
-            "with_object",
-            "with_promise",
-          ]
-
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: "Set up node ${{ matrix.node-version }}"
-        id: setup-node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "${{ matrix.node-version }}"
-          cache: "npm"
-
-      - name: "Link top-level"
-        run: npm link
-
-      - name: "Install dependencies"
-        run: npm ci
-        working-directory: "examples"
-
-      - name: "Link local framework"
-        run: npm link @scaleway/serverless-functions
-        working-directory: "examples"
-
-      - name: "Run example"
-        run: node ${{ matrix.example }}/handler.js &
-        working-directory: "examples"
-
-      - name: "Wait for it to start"
-        run: sleep 1
-
-      - name: "Launch a request"
-        run: curl http://localhost:8080
-        working-directory: "examples"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Serverless Functions Node
 
-[![build-and-test](https://github.com/scaleway/serverless-functions-node/actions/workflows/npmtest.yml/badge.svg)](https://github.com/scaleway/serverless-functions-node/actions/workflows/npmtest.yml)
-![node](https://img.shields.io/badge/node-16_|_18-blue.svg)
+![Tests](https://github.com/scaleway/serverless-functions-node/actions/workflows/tests.yml/badge.svg)
+![Examples](https://github.com/scaleway/serverless-functions-node/actions/workflows/examples.yml/badge.svg)
+[![NPM Version](https://img.shields.io/npm/v/@scaleway/serverless-functions.svg)](https://www.npmjs.com/package/@scaleway/serverless-functions)
+![Node](https://img.shields.io/badge/node-16_|_18-blue.svg)
 
 Scaleway Serverless Functions Node is a framework which simplifies working with [Scaleway Serverless Functions](https://www.scaleway.com/en/serverless-functions/).
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -29,6 +29,7 @@ To release a new version:
 - Create a PR (or add to an existing PR)
 - Merge the PR to `main`
 - Create a new Release [in Github](https://github.com/scaleway/serverless-functions-node/releases)
+- Check that the `publish` pipeline succeeded
 
 Please follow [Semantic Versioning](https://semver.org/) guidelines when deciding which version to go to.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,12 @@
 # Examples
 
-Each example contains a `handler.js` file.
-
-To run them, you first need to install the dependencies in this directory:
+To run the examples, you first need to install the examples dependencies:
 
 ```console
 npm i
 ```
 
-Then you can run examples with:
+You can then run each example with:
 
 ```console
 node <example_name>/handler.js

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.305.0",
-        "@scaleway/serverless-functions": "^1.0.2",
+        "@scaleway/serverless-functions": "^1.1.0",
         "https": "^1.0.0",
         "parse-multipart-data": "^1.5.0"
       }
@@ -808,12 +808,12 @@
       }
     },
     "node_modules/@scaleway/serverless-functions": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@scaleway/serverless-functions/-/serverless-functions-1.0.2.tgz",
-      "integrity": "sha512-rTfOTvGrVfi00JWckjP+JsJtBjvquQC6+RN3RCfEqYG9od38sLW++5uu9hcuOS+ZjxqkcF/+nPB2uUzmrxR6Rw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scaleway/serverless-functions/-/serverless-functions-1.1.0.tgz",
+      "integrity": "sha512-6r93gsTinI3K/NEZmsMxu+1fTqTWKajTlH9C0CPEGifW460pl7m+Fa0PHKz7GKbzS6e50XpWl94N2wlqv2syaQ==",
       "dependencies": {
         "@fastify/url-data": "^5.3.1",
-        "@types/node": "^18.15.11",
+        "@types/node": "^20.1.4",
         "fastify": "^4.15.0"
       }
     },
@@ -1434,9 +1434,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.18.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
-      "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2781,12 +2781,12 @@
       }
     },
     "@scaleway/serverless-functions": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@scaleway/serverless-functions/-/serverless-functions-1.0.2.tgz",
-      "integrity": "sha512-rTfOTvGrVfi00JWckjP+JsJtBjvquQC6+RN3RCfEqYG9od38sLW++5uu9hcuOS+ZjxqkcF/+nPB2uUzmrxR6Rw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scaleway/serverless-functions/-/serverless-functions-1.1.0.tgz",
+      "integrity": "sha512-6r93gsTinI3K/NEZmsMxu+1fTqTWKajTlH9C0CPEGifW460pl7m+Fa0PHKz7GKbzS6e50XpWl94N2wlqv2syaQ==",
       "requires": {
         "@fastify/url-data": "^5.3.1",
-        "@types/node": "^18.15.11",
+        "@types/node": "^20.1.4",
         "fastify": "^4.15.0"
       }
     },
@@ -3287,9 +3287,9 @@
       }
     },
     "@types/node": {
-      "version": "18.18.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
-      "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
       "requires": {
         "undici-types": "~5.26.4"
       }

--- a/examples/package.json
+++ b/examples/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.305.0",
-    "@scaleway/serverless-functions": "^1.0.2",
+    "@scaleway/serverless-functions": "^1.1.0",
     "https": "^1.0.0",
     "parse-multipart-data": "^1.5.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,30 +119,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
-      "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
+      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
-      "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
+      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helper-module-transforms": "^7.23.3",
         "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.0",
+        "@babel/parser": "^7.23.3",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0",
+        "@babel/traverse": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -167,12 +167,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -253,9 +253,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
-      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -431,9 +431,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
+      "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -605,9 +605,9 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
-      "integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
+      "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -634,19 +634,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -655,9 +655,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -1820,9 +1820,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.578",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.578.tgz",
-      "integrity": "sha512-V0ZhSu1BQZKfG0yNEL6Dadzik8E1vAzfpVOapdSiT9F6yapEJ3Bk+4tZ4SMPdWiUchCgnM/ByYtBzp5ntzDMIA==",
+      "version": "1.4.579",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.579.tgz",
+      "integrity": "sha512-bJKvA+awBIzYR0xRced7PrQuRIwGQPpo6ZLP62GAShahU9fWpsNN2IP6BSP1BLDDSbxvBVRGAMWlvVVq3npmLA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4313,27 +4313,27 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
-      "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
+      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
-      "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
+      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helper-module-transforms": "^7.23.3",
         "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.0",
+        "@babel/parser": "^7.23.3",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0",
+        "@babel/traverse": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -4350,12 +4350,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -4417,9 +4417,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
-      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -4552,9 +4552,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -4603,9 +4603,9 @@
       }
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
+      "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -4675,9 +4675,9 @@
       }
     },
     "@babel/plugin-syntax-typescript": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
-      "integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
+      "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -4695,27 +4695,27 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -5603,9 +5603,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.578",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.578.tgz",
-      "integrity": "sha512-V0ZhSu1BQZKfG0yNEL6Dadzik8E1vAzfpVOapdSiT9F6yapEJ3Bk+4tZ4SMPdWiUchCgnM/ByYtBzp5ntzDMIA==",
+      "version": "1.4.579",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.579.tgz",
+      "integrity": "sha512-bJKvA+awBIzYR0xRced7PrQuRIwGQPpo6ZLP62GAShahU9fWpsNN2IP6BSP1BLDDSbxvBVRGAMWlvVVq3npmLA==",
       "dev": true
     },
     "emittery": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scaleway/serverless-functions",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@scaleway/serverless-functions",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/url-data": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@scaleway/serverless-functions",
   "version": "1.1.0",
   "description": "",
-  "main": "framework/dist/local/index.js",
-  "types": "framework/dist/local/index.d.ts",
+  "main": "framework/dist/framework/local/index.js",
+  "types": "framework/dist/framework/local/index.d.ts",
   "scripts": {
     "build": "node_modules/.bin/tsc -p tsconfig.json",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scaleway/serverless-functions",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "framework/dist/framework/local/index.js",
   "types": "framework/dist/framework/local/index.d.ts",


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Fix paths in top-level `package.json`
- Split examples into separate workflow (with its own badge :sunglasses:)
- Fix tests badge which was broken in last PR
- Add npm badge
- Give workflows consistent names

**_Why do we need this?_**

- Bad paths in top-level `package.json` broke imports
- Badges were broken 
- Didn't have a link to the npm package 
- Workflows were named using relative paths to YAML

**_How have you tested it?_**

See branch version here: https://github.com/scaleway/serverless-functions-node/tree/readme-fix

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [x] I have updated the relevant documentation